### PR TITLE
switch the entire parallel computing approach

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,10 +17,11 @@ Imports:
     vegperiod (>= 0.2.1),
     foreach,
     iterators,
-    doSNOW,
-    snow,
-	sirad,
-	methods
+    doFuture,
+    future,
+    progressr,
+    sirad,
+    methods
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+LWFBrook90R v0.?.? (Release date: ???)
+==============
+Changes:
+* switched `msiterunLWFB90()` and `mrunLWFB90()` from superseded packages `snow` and `doSNOW` to `future`, `doFuture` and `progressr` for parallel computation and progress reporting thereof. Pacifies a check note and is more future-proof.
+
+
 LWFBrook90R v0.3.4 (Release date: 2020-08-28)
 ==============
 

--- a/R/mrunLWFB90.R
+++ b/R/mrunLWFB90.R
@@ -38,13 +38,12 @@
 #' the column has to be named 'maxlai3'.
 #'
 #' @section Progress bar:
-#' This function supports progress bars via the package \CRANpkg{progressr}.
-#' The parameter \code{showProgress=TRUE} wraps the parallized part in
-#' [progressr::with_progress()] to display a progress bar. The look of the
-#' progress bar can be changed via \code{progressr::handlers()}. We recommend
-#' to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
-#' but many other fancy styles are possible, including acoustic updates
-#' (cf. \code{vignette('progressr-intro')}).
+#' This function provides a progress bar via the package \CRANpkg{progressr}
+#' if \code{showProgress=TRUE}. The parallel computation is then wrapped with
+#' \code{progressr::with_progress()} to enable progress reporting from
+#' distributed calculations. The appearance of the progress bar (including
+#' audible notification) can be customized by the user for the entire session
+#' using \code{progressr::handlers()} (see \code{vignette('progressr-intro')}).
 #'
 #' @export
 #'

--- a/R/mrunLWFB90.R
+++ b/R/mrunLWFB90.R
@@ -11,9 +11,10 @@
 #' @param multirun.dir Directory name where to create the subdirectories for the single runs. Default is 'MultiRuns/'.
 #' @param keep.subdirs Keep sub-directories of the single runs? Default is FALSE.
 #' @param cores Number of CPUs to use for parallel processing. Default is 2.
-#' @param showProgress Show progressbar? Default is TRUE.
+#' @param showProgress Show progressbar? Default is TRUE. See also section \code{Progress bar}.
 #' @param ... Additional arguments passed to \code{\link{runLWFB90}}:
 #' provide at least the arguments that have no defaults (\code{options.b90} and \code{climate})!
+#' It might be a good idea to also pass \code{verbose=FALSE} to supress excessive chatter of \code{runLWFB90}.
 #'
 #' @return A named list with the results of the single runs as returned by \code{\link{runLWFB90}}.
 #' Simulation or processing errors are passed on.
@@ -36,6 +37,15 @@
 #' has to be called 'soil_materials.ths2'. In order to replace the 3rd value of \code{maxlai} vector in \code{param.b90},
 #' the column has to be named 'maxlai3'.
 #'
+#' @section Progress bar:
+#' This function supports progress bars via the package \CRANpkg{progressr}.
+#' The parameter \code{showProgress=TRUE} wraps the parallized part in
+#' [progressr::with_progress()] to display a progress bar. The look of the
+#' progress bar can be changed via \code{progressr::handlers()}. We recommend
+#' to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
+#' but many other fancy styles are possible, including acoustic updates
+#' (cf. \code{vignette('progressr-intro')}).
+#'
 #' @export
 #'
 #' @examples
@@ -54,6 +64,7 @@
 #'
 #' #set up data.frame with variable parameters
 #' n <- 5
+#' set.seed(2020)
 #' vary_parms <- data.frame(shape.optdoy = runif(n,180,240),
 #'                          shape.budburst = runif(n, 0.1,1),
 #'                          winlaifrac = runif(n, 0,0.5),
@@ -98,7 +109,14 @@ mrunLWFB90 <- function(paramvar,
                        cores = 2,
                        showProgress = TRUE,
                        ...){
-  i <- NULL #to pass CRAN check Notes
+
+  if(cores > future::availableCores())
+    stop(paste("Can not run on", cores, "cores! Only", future::availableCores(),
+               "available."))
+
+  # to pass CRAN check Notes
+  i <- NULL
+  `%dopar%` <- foreach::`%dopar%`
 
   nRuns <- nrow(paramvar)
 
@@ -136,62 +154,60 @@ mrunLWFB90 <- function(paramvar,
     dir.create(multirun.dir)
   }
 
-  # set up local %dopar%
-  `%dopar%` <- foreach::`%dopar%`
+  # set up Cluster and define foreach-Loop ------------------------------------------
+  # plan multisession does makeClusterPSOCK() in the background
+  # cluster is stoped automagically on exit
+  # a future plan that might have existied before will be restored on exit
+  oplan <- future::plan(future::multisession, workers=cores)
+  on.exit(future::plan(oplan), add=TRUE)
+  doFuture::registerDoFuture()
 
-  # set up Cluster and progressbar --------------------------------------------------
+  foreach_loop <- function(){
+    foreach::foreach(
+      i = 1:nRuns,
+      .final = function(x) stats::setNames(x, paste0("RunNo.", 1:nRuns)),
+      .errorhandling = "pass",
+      .export = "param.b90") %dopar% {
 
-  progress <- function(nRuns) utils::setTxtProgressBar(pb, nRuns)
+        # replace single value parameters
+        param.b90[match(singlepar_nms,names(param.b90))] <- paramvar[i,match(singlepar_nms, paramvar_nms, nomatch = 0)]
 
-  if (showProgress) {
-    opts <- list(progress = progress)
-  } else {
-    opts <- list(progress = NULL)
+        # replace parameters in data.frames and vector elements
+        if (param_ll_len > 0) {
+          for (l in 1:length(param_ll)){
+            list_ind <- which(names(param.b90) == names(param_ll)[l])
+            param.b90[[ list_ind ]] <- replace_vecelements(param.b90[[ list_ind ]],
+                                                           varnms = paramvar_nms[ param_ll[[l]] ],
+                                                           vals = unlist(paramvar[i, unlist(param_ll[[l]])]))
+          }
+        }
+        # Set up directory name
+        proj.dir <- file.path(multirun.dir,paste0("RunNo.",i))
+
+        # Run LWFBrook90
+        res <- runLWFB90(project.dir = proj.dir,
+                         param.b90 = param.b90,
+                         ...)
+
+        increment_progressbar()
+
+        if (!keep.subdirs) {
+          unlink(file.path(proj.dir), recursive = TRUE)
+        }
+        return(res)
+      }
   }
-  #
-  cl <- snow::makeSOCKcluster(cores)
-  doSNOW::registerDoSNOW(cl)
-  snow::clusterEvalQ(cl, library("LWFBrook90R"))
-  on.exit(snow::stopCluster(cl), add = T)
 
-  pb <- utils::txtProgressBar(min = 1, max = nRuns, style = 3)
-
-  # foreach-Loop --------------------------------------------------------------------
-  results <- foreach::foreach(i = 1:nRuns,
-                              .final = function(x) stats::setNames(x, paste0("RunNo.", 1:nRuns)),
-                              .errorhandling = "pass",
-                              .options.snow = opts) %dopar% {
-
-                                # replace single value parameters
-                                param.b90[match(singlepar_nms,names(param.b90))] <- paramvar[i,match(singlepar_nms, paramvar_nms, nomatch = 0)]
-
-                                # replace parameters in data.frames and vector elements
-                                if (param_ll_len > 0) {
-                                  for (l in 1:length(param_ll)){
-                                    list_ind <- which(names(param.b90) == names(param_ll)[l])
-                                    param.b90[[ list_ind ]] <- replace_vecelements(param.b90[[ list_ind ]],
-                                                                                   varnms = paramvar_nms[ param_ll[[l]] ],
-                                                                                   vals = unlist(paramvar[i, unlist(param_ll[[l]])]))
-                                    }
-                                }
-                                # Set up directory name
-                                proj.dir <- file.path(multirun.dir,paste0("RunNo.",i))
-
-                                # Run LWFBrook90
-                                res <- runLWFB90(project.dir = proj.dir,
-                                                 param.b90 = param.b90,
-                                                 ...)
-
-                                if (!keep.subdirs) {
-                                  unlink(file.path(proj.dir), recursive = TRUE)
-                                }
-                                return(res)
-                              }
+  # with progressbar if wanted
+  if(isTRUE(showProgress)){
+    progressr::with_progress({
+      increment_progressbar <- progressr::progressor(steps=nRuns)
+      results <- foreach_loop()
+    })
+  } else {
+    increment_progressbar <- function(){}
+    results <- foreach_loop()
+  }
 
   return(results)
 }
-
-
-
-
-

--- a/R/msiterunLWFB90.R
+++ b/R/msiterunLWFB90.R
@@ -33,13 +33,12 @@
 #' perform directly on the output of a single run simulation, and can be used for aggrating model output on-the-fly.
 #'
 #' @section Progress bar:
-#' This function supports progress bars via the package \CRANpkg{progressr}.
-#' The parameter \code{showProgress=TRUE} wraps the parallized part in
-#' [progressr::with_progress()] to display a progress bar. The look of the
-#' progress bar can be changed via \code{progressr::handlers()}. We recommend
-#' to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
-#' but many other fancy styles are possible, including acoustic updates
-#' (cf. \code{vignette('progressr-intro')}).
+#' This function provides a progress bar via the package \CRANpkg{progressr}
+#' if \code{showProgress=TRUE}. The parallel computation is then wrapped with
+#' \code{progressr::with_progress()} to enable progress reporting from
+#' distributed calculations. The appearance of the progress bar (including
+#' audible notification) can be customized by the user for the entire session
+#' using \code{progressr::handlers()} (see \code{vignette('progressr-intro')}).
 #'
 #' @export
 #'

--- a/README.md
+++ b/README.md
@@ -11,17 +11,6 @@ hydrological model from within R
 
 ## Installation
 
-Before installing the package, the following imported packages need to
-be installed from CRAN:
-
-``` r
-install.packages("data.table")
-install.packages("vegperiod")
-install.packages("sirad")
-install.packages("foreach")
-install.packages("doSNOW")
-```
-
 ### Recommended installation
 
 It is recommended to download and install the latest stable release from

--- a/man/mrunLWFB90.Rd
+++ b/man/mrunLWFB90.Rd
@@ -68,13 +68,12 @@ the column has to be named 'maxlai3'.
 
 \section{Progress bar}{
 
-This function supports progress bars via the package \CRANpkg{progressr}.
-The parameter \code{showProgress=TRUE} wraps the parallized part in
-[progressr::with_progress()] to display a progress bar. The look of the
-progress bar can be changed via \code{progressr::handlers()}. We recommend
-to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
-but many other fancy styles are possible, including acoustic updates
-(cf. \code{vignette('progressr-intro')}).
+This function provides a progress bar via the package \CRANpkg{progressr}
+if \code{showProgress=TRUE}. The parallel computation is then wrapped with
+\code{progressr::with_progress()} to enable progress reporting from
+distributed calculations. The appearance of the progress bar (including
+audible notification) can be customized by the user for the entire session
+using \code{progressr::handlers()} (see \code{vignette('progressr-intro')}).
 }
 
 \examples{

--- a/man/mrunLWFB90.Rd
+++ b/man/mrunLWFB90.Rd
@@ -30,10 +30,11 @@ respective column of \code{paramvar}. All parameter names (column names) in \cod
 
 \item{cores}{Number of CPUs to use for parallel processing. Default is 2.}
 
-\item{showProgress}{Show progressbar? Default is TRUE.}
+\item{showProgress}{Show progressbar? Default is TRUE. See also section \code{Progress bar}.}
 
 \item{...}{Additional arguments passed to \code{\link{runLWFB90}}:
-provide at least the arguments that have no defaults (\code{options.b90} and \code{climate})!}
+provide at least the arguments that have no defaults (\code{options.b90} and \code{climate})!
+It might be a good idea to also pass \code{verbose=FALSE} to supress excessive chatter of \code{runLWFB90}.}
 }
 \value{
 A named list with the results of the single runs as returned by \code{\link{runLWFB90}}.
@@ -65,6 +66,17 @@ has to be called 'soil_materials.ths2'. In order to replace the 3rd value of \co
 the column has to be named 'maxlai3'.
 }
 
+\section{Progress bar}{
+
+This function supports progress bars via the package \CRANpkg{progressr}.
+The parameter \code{showProgress=TRUE} wraps the parallized part in
+[progressr::with_progress()] to display a progress bar. The look of the
+progress bar can be changed via \code{progressr::handlers()}. We recommend
+to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
+but many other fancy styles are possible, including acoustic updates
+(cf. \code{vignette('progressr-intro')}).
+}
+
 \examples{
 # Set up lists containing model control options and model parameters:
 param.b90 <- setparam_LWFB90()
@@ -81,6 +93,7 @@ soil <- cbind(slb1_soil, hydpar_wessolek_mvg(slb1_soil$texture))
 
 #set up data.frame with variable parameters
 n <- 5
+set.seed(2020)
 vary_parms <- data.frame(shape.optdoy = runif(n,180,240),
                          shape.budburst = runif(n, 0.1,1),
                          winlaifrac = runif(n, 0,0.5),

--- a/man/msiterunLWFB90.Rd
+++ b/man/msiterunLWFB90.Rd
@@ -65,13 +65,12 @@ perform directly on the output of a single run simulation, and can be used for a
 
 \section{Progress bar}{
 
-This function supports progress bars via the package \CRANpkg{progressr}.
-The parameter \code{showProgress=TRUE} wraps the parallized part in
-[progressr::with_progress()] to display a progress bar. The look of the
-progress bar can be changed via \code{progressr::handlers()}. We recommend
-to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
-but many other fancy styles are possible, including acoustic updates
-(cf. \code{vignette('progressr-intro')}).
+This function provides a progress bar via the package \CRANpkg{progressr}
+if \code{showProgress=TRUE}. The parallel computation is then wrapped with
+\code{progressr::with_progress()} to enable progress reporting from
+distributed calculations. The appearance of the progress bar (including
+audible notification) can be customized by the user for the entire session
+using \code{progressr::handlers()} (see \code{vignette('progressr-intro')}).
 }
 
 \examples{

--- a/man/msiterunLWFB90.Rd
+++ b/man/msiterunLWFB90.Rd
@@ -36,9 +36,10 @@ running one or multiple param.b90/options.b90 combinations for a series of clima
 
 \item{cores}{Number of cores to use for parallel processing.}
 
-\item{showProgress}{Logical: Show progressbar?}
+\item{showProgress}{Logical: Show progressbar? Default is TRUE. See also section \code{Progress bar}.}
 
-\item{...}{Further arguments passed to \code{\link{runLWFB90}}.}
+\item{...}{Further arguments passed to \code{\link{runLWFB90}}.
+It might be a good idea to pass \code{verbose=FALSE} to supress excessive chatter of \code{runLWFB90}.}
 }
 \value{
 A named list with the results of the single runs as returned by \code{\link{runLWFB90}}.
@@ -60,6 +61,17 @@ if many simulations are done and the selected output contains daily resolution d
 To not overload memory, it is advised to reduce the returned simulation results to a minimum, by carefully selecting the output,
 and make use of the option to pass a list of functions to \code{\link{runLWFB90}} (argument \code{output_fun}). These functions
 perform directly on the output of a single run simulation, and can be used for aggrating model output on-the-fly.
+}
+
+\section{Progress bar}{
+
+This function supports progress bars via the package \CRANpkg{progressr}.
+The parameter \code{showProgress=TRUE} wraps the parallized part in
+[progressr::with_progress()] to display a progress bar. The look of the
+progress bar can be changed via \code{progressr::handlers()}. We recommend
+to use package \CRANpkg{progress} with \code{progressr::handlers("progress")}
+but many other fancy styles are possible, including acoustic updates
+(cf. \code{vignette('progressr-intro')}).
 }
 
 \examples{


### PR DESCRIPTION
As described in detail in issue #28, this pull request switches the parallel computing code from the superseded `snow & doSNOW` to `future, doFuture & progressr`.

The foreach-code remained unchanged (the snow-opts were droped and only one additional export was needed).

The results of the examples of `mrunLWFB90()` and `msiterunLWFB90()` are identical before and after the switch (warnings now displayed by mrunLWFB90() were so far concealed by doSNOW and foreach cf. #30).