### PR TITLE
Better error messages in set_paramLWFB90()

### DIFF
--- a/R/setparms_LWFB90.R
+++ b/R/setparms_LWFB90.R
@@ -252,9 +252,11 @@ set_paramLWFB90 <- function(...) {
 
   if (length(dots) > 0 ) {
     if (length(dots[which(names(dots) %in% names(param))]) < length(dots)) {
-      warning(paste("Not all arguments found in list! Check names:",
-                    names(dots[which(!names(dots) %in% names(param))])
-      ))
+      stop(
+        paste("Not all arguments found in list!\nCheck names:",
+              paste0(names(dots[which(!names(dots) %in% names(param))]),
+                     collapse = ", ")
+        ))
     }
     param[match(names(dots),names(param))] <- dots
   }

--- a/R/setparms_LWFB90.R
+++ b/R/setparms_LWFB90.R
@@ -253,7 +253,7 @@ set_paramLWFB90 <- function(...) {
   if (length(dots) > 0 ) {
     if (length(dots[which(names(dots) %in% names(param))]) < length(dots)) {
       stop(
-        paste("Not all arguments found in list!\nCheck names:",
+        paste("Invalid parameters provided!\nCheck names:",
               paste0(names(dots[which(!names(dots) %in% names(param))]),
                      collapse = ", ")
         ))


### PR DESCRIPTION
The function set_paramLWFB90() **passes with a single invalid argument**, but fails with multiple. The error is caused later when assigning the parameters, which gives an error message that is not as helpful.

``` r
params <- LWFBrook90R::set_paramLWFB90(aaa = 1)
#> Warning in LWFBrook90R::set_paramLWFB90(aaa = 1): Not all arguments found in
#> list! Check names: aaa
params <- LWFBrook90R::set_paramLWFB90(aaa = 1, bbb = 1)
#> Warning in LWFBrook90R::set_paramLWFB90(aaa = 1, bbb = 1): Not all arguments
#> found in list! Check names: aaaNot all arguments found in list! Check names:
#> bbb
#> Error in param[match(names(dots), names(param))] <- dots: NAs are not allowed in subscripted assignments
```

<sup>Created on 2025-04-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The change makes it fail for any number of invalid arguments and gives a more helpful error message.

``` r
params <- LWFBrook90R::set_paramLWFB90(aaa = 1)
#> Error in LWFBrook90R::set_paramLWFB90(aaa = 1): Invalid parameters provided!
#> Check names: aaa
params <- LWFBrook90R::set_paramLWFB90(aaa = 1, bbb = 1)
#> Error in LWFBrook90R::set_paramLWFB90(aaa = 1, bbb = 1): Invalid parameters provided!
#> Check names: aaa, bbb
```

<sup>Created on 2025-04-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

